### PR TITLE
Complex Webpack compiler destructuring

### DIFF
--- a/IconThemePlugin.js
+++ b/IconThemePlugin.js
@@ -7,7 +7,7 @@ class IconThemePlugin {
 
   apply(compiler) {
     const pluginName = IconThemePlugin.name;
-    const {webpack: {RawSource}} = compiler;
+    const {webpack: {source: {RawSource}}} = compiler;
 
     compiler.hooks.emit.tap(pluginName, (compilation) => {
       const icons = compilation.getAssets().map(


### PR DESCRIPTION
Unfortunately the previous suggested method did not work, and the whole nested path to the desired properties was required.